### PR TITLE
ViewModelの初期化方法変更

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/HotPepperAPI" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
@@ -6,14 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import com.example.hotpepperapi.databinding.FragmentStoreDetailBinding
 import com.example.hotpepperapi.viewModel.ViewModel
 
 class StoreDetailFragment : Fragment() {
 
     private lateinit var binding: FragmentStoreDetailBinding
-    private lateinit var viewModel: ViewModel
+    private val viewModel: ViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,9 +25,6 @@ class StoreDetailFragment : Fragment() {
             container,
             false
         )
-        viewModel = ViewModelProvider(requireActivity())[ViewModel::class.java]
-        binding.dataViewModel = viewModel
-        binding.lifecycleOwner = viewLifecycleOwner
 
         return binding.root
     }

--- a/app/src/main/java/com/example/hotpepperapi/fragment/StoreListFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/StoreListFragment.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.hotpepperapi.R
 import com.example.hotpepperapi.databinding.FragmentStoreListBinding
@@ -17,9 +17,7 @@ import com.example.hotpepperapi.viewModel.ViewModel
 class StoreListFragment : Fragment() {
 
     private lateinit var binding: FragmentStoreListBinding
-
-        private lateinit var viewModel: ViewModel
-//    private val viewModel: ViewModel by viewModels()
+    private val viewModel: ViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,9 +29,6 @@ class StoreListFragment : Fragment() {
             container,
             false
         )
-        viewModel = ViewModelProvider(requireActivity())[ViewModel::class.java]
-        binding.dataViewModel = viewModel
-        binding.lifecycleOwner = viewLifecycleOwner
 
         Log.i("StoreListFragment", "onCreateView")
         return binding.root

--- a/app/src/main/java/com/example/hotpepperapi/fragment/TopFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/TopFragment.kt
@@ -10,7 +10,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.hotpepperapi.R
 import com.example.hotpepperapi.databinding.FragmentTopBinding
@@ -18,8 +18,7 @@ import com.example.hotpepperapi.viewModel.ViewModel
 
 class TopFragment : Fragment() {
 
-//    private val viewModel: ViewModel by viewModels()
-    private lateinit var viewModel: ViewModel
+    private val viewModel: ViewModel by activityViewModels()
     private lateinit var binding: FragmentTopBinding
 
     override fun onCreateView(
@@ -29,9 +28,6 @@ class TopFragment : Fragment() {
         binding = DataBindingUtil.inflate(
             inflater, R.layout.fragment_top, container, false
         )
-        viewModel = ViewModelProvider(requireActivity())[ViewModel::class.java]
-        binding.dataViewModel = viewModel
-        binding.lifecycleOwner = viewLifecycleOwner
 
         ArrayAdapter.createFromResource(
             requireContext(),

--- a/app/src/main/res/layout/fragment_store_detail.xml
+++ b/app/src/main/res/layout/fragment_store_detail.xml
@@ -21,16 +21,16 @@
             android:id="@+id/tv_store_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
+            android:gravity="center_horizontal"
             android:textSize="30sp"
             android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="@string/hello_blank_fragment" />
+            tools:text="@string/app_name" />
 
         <TextView
             android:id="@+id/tv_genre"

--- a/app/src/main/res/layout/fragment_top.xml
+++ b/app/src/main/res/layout/fragment_top.xml
@@ -105,7 +105,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:backgroundTint="@color/navy"
-            android:text="@string/_300m"
+            android:text="@string/distance_300m"
             app:layout_constraintEnd_toStartOf="@+id/btn_500"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_location" />
@@ -116,7 +116,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:backgroundTint="@color/navy"
-            android:text="@string/_500m"
+            android:text="@string/distance_500m"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/btn_300"
             app:layout_constraintTop_toBottomOf="@+id/tv_location" />


### PR DESCRIPTION
### **PR対応内容**

- onCreateView()内で初期化していたViewModelを各Fragmentのフィールドで初期化
- [develop3](https://github.com/hirotomo-yamazaki/HotPepperAPI/pull/3)との機能上の変更はありません。

### **動作確認内容**

- [develop3](https://github.com/hirotomo-yamazaki/HotPepperAPI/pull/3)と同様の仕様となっている。

### **仕様について**
[アプリの仕様](https://docs.google.com/document/d/1g1koq54AMI1GQBK1CSDwK_GfaSHeKFbhXy4amhJ1LD8/edit?usp=sharing)

### **トップ画面**
![スクリーンショット 2022-11-21 15 29 47](https://user-images.githubusercontent.com/112037699/202980799-9e504bd4-3b3a-481c-a6d5-0bc0e30d13fa.png)

### **店名一覧画面**
![スクリーンショット 2022-11-21 15 30 09](https://user-images.githubusercontent.com/112037699/202980975-5602084e-ab71-4c44-a1a0-f0339cdd9548.png)

### **店舗詳細画面**
![スクリーンショット 2022-11-21 15 30 28](https://user-images.githubusercontent.com/112037699/202981059-a60fdd8d-96c8-4c5c-b9e6-09878bcedc2d.png)

