### PR TITLE
Map表示追加

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_4_API_31.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_5_API_31_2.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-11-24T02:56:40.712594Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-11-29T06:13:53.099754Z" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -15,6 +17,11 @@
         android:theme="@style/Theme.HotPepperAPI"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyDV7xMT1NNuxj-5YjzT34A-KsKPE9QECYI" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/hotpepperapi/MainActivity.kt
+++ b/app/src/main/java/com/example/hotpepperapi/MainActivity.kt
@@ -24,9 +24,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     @SuppressLint("MissingPermission")
-    private fun location(){
+    private fun location() {
         fusedLocationClient.lastLocation
-            .addOnSuccessListener { location : Location? ->
+            .addOnSuccessListener { location: Location? ->
                 // Got last known location. In some rare situations this can be null.
                 if (location != null) {
                     val latitude = location.latitude

--- a/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
@@ -1,0 +1,56 @@
+package com.example.hotpepperapi.fragment
+
+import androidx.fragment.app.Fragment
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import com.example.hotpepperapi.R
+import com.example.hotpepperapi.viewModel.ViewModel
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+
+class MapsFragment : Fragment() {
+
+    private lateinit var callback: OnMapReadyCallback
+    private val viewModel: ViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_maps, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        callback = OnMapReadyCallback { googleMap ->
+
+            viewModel.storeLat.observe(viewLifecycleOwner) { lat ->
+                viewModel.storeLng.observe(viewLifecycleOwner) { lng ->
+                    val store = LatLng(lat, lng)
+
+                    Log.i("MFlat", viewModel.storeLat.value.toString())
+                    Log.i("MFlng", viewModel.storeLng.value.toString())
+
+                    googleMap.addMarker(
+                        MarkerOptions().position(store).title(viewModel.storeName.value)
+                    )
+                    googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(store, 15F)) //zoom表示
+                    googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
+                    googleMap.uiSettings.isZoomControlsEnabled = true //zoomボタン表示
+                }
+            }
+        }
+
+        val mapFragment = childFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
+        mapFragment?.getMapAsync(callback)
+    }
+}

--- a/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.example.hotpepperapi.R
 import com.example.hotpepperapi.databinding.FragmentStoreDetailBinding
 import com.example.hotpepperapi.viewModel.ViewModel
 
@@ -21,7 +23,7 @@ class StoreDetailFragment : Fragment() {
     ): View {
         binding = DataBindingUtil.inflate(
             inflater,
-            com.example.hotpepperapi.R.layout.fragment_store_detail,
+            R.layout.fragment_store_detail,
             container,
             false
         )
@@ -35,6 +37,7 @@ class StoreDetailFragment : Fragment() {
         viewModel.storeList.observe(viewLifecycleOwner) { list ->
             viewModel.position.observe(viewLifecycleOwner) { position ->
                 binding.tvStoreName.text = list[position]
+                viewModel.setStoreName(list[position])
             }
         }
 
@@ -50,10 +53,22 @@ class StoreDetailFragment : Fragment() {
             }
         }
 
+        viewModel.latList.observe(viewLifecycleOwner) { lat ->
+            viewModel.lngList.observe(viewLifecycleOwner) { lng ->
+                viewModel.position.observe(viewLifecycleOwner) { position ->
+                    viewModel.setStoreLatLng(lat[position], lng[position])
+                }
+            }
+        }
+
         viewModel.accessList.observe(viewLifecycleOwner) { list ->
             viewModel.position.observe(viewLifecycleOwner) { position ->
                 binding.tvStoreAccess.text = list[position]
             }
+        }
+
+        binding.tvStoreAddress.setOnClickListener {
+            findNavController().navigate(R.id.action_storeDetailFragment_to_mapsFragment)
         }
     }
 }

--- a/app/src/main/java/com/example/hotpepperapi/fragment/StoreListFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/StoreListFragment.kt
@@ -37,6 +37,14 @@ class StoreListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        viewModel.progressBarFlag.observe(viewLifecycleOwner) { flag ->
+            if (flag == true) {
+                showProgressBar()
+            } else {
+                hideProgressBar()
+            }
+        }
+
         viewModel.storeList.observe(viewLifecycleOwner) {
             binding.lv300.adapter = ArrayAdapter(
                 requireContext(),
@@ -51,5 +59,13 @@ class StoreListFragment : Fragment() {
         }
 
         Log.i("StoreListFragment", "onViewCreated")
+    }
+
+    private fun hideProgressBar() {
+        binding.progressBar.visibility = View.INVISIBLE
+    }
+
+    private fun showProgressBar() {
+        binding.progressBar.visibility = View.VISIBLE
     }
 }

--- a/app/src/main/java/com/example/hotpepperapi/model/Pc.kt
+++ b/app/src/main/java/com/example/hotpepperapi/model/Pc.kt
@@ -1,7 +1,0 @@
-package com.example.hotpepperapi.model
-
-data class Pc(
-    val l: String,
-    val m: String,
-    val s: String
-) : java.io.Serializable

--- a/app/src/main/java/com/example/hotpepperapi/model/Photo.kt
+++ b/app/src/main/java/com/example/hotpepperapi/model/Photo.kt
@@ -2,5 +2,4 @@ package com.example.hotpepperapi.model
 
 data class Photo(
     val mobile: Mobile,
-    val pc: Pc
 ) : java.io.Serializable

--- a/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
+++ b/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
@@ -14,6 +14,10 @@ import retrofit2.Response
 
 class ViewModel : ViewModel() {
 
+    private val _progressBarFlag = MutableLiveData<Boolean>()
+    val progressBarFlag: LiveData<Boolean>
+        get() = _progressBarFlag
+
     private val _genreCode = MutableLiveData<String>()
     val genreCode: LiveData<String>
         get() = _genreCode
@@ -38,6 +42,14 @@ class ViewModel : ViewModel() {
     val accessList: LiveData<MutableList<String>>
         get() = _accessList
 
+    private val _latList = MutableLiveData<MutableList<Double>>()
+    val latList: LiveData<MutableList<Double>>
+        get() = _latList
+
+    private val _lngList = MutableLiveData<MutableList<Double>>()
+    val lngList: LiveData<MutableList<Double>>
+        get() = _lngList
+
     private val _position = MutableLiveData<Int>()
     val position: LiveData<Int>
         get() = _position
@@ -50,7 +62,20 @@ class ViewModel : ViewModel() {
     val lng: LiveData<Double>
         get() = _lng
 
+    private val _storeLat = MutableLiveData<Double>()
+    val storeLat: LiveData<Double>
+        get() = _storeLat
+
+    private val _storeLng = MutableLiveData<Double>()
+    val storeLng: LiveData<Double>
+        get() = _storeLng
+
+    private val _storeName = MutableLiveData<String>()
+    val storeName: LiveData<String>
+        get() = _storeName
+
     init {
+        _progressBarFlag.value = false
         _genreCode.value = ""
         _etKeyword.value = ""
         _storeList.value = mutableListOf()
@@ -60,6 +85,11 @@ class ViewModel : ViewModel() {
         _accessList.value = mutableListOf()
         _lat.value = 35.6809591
         _lng.value = 139.7673068
+        _storeLat.value = 35.6809591
+        _storeLng.value = 139.7673068
+        _storeName.value = ""
+        _latList.value = mutableListOf()
+        _lngList.value = mutableListOf()
     }
 
     fun setKeyword(keyword: String) {
@@ -74,11 +104,21 @@ class ViewModel : ViewModel() {
         _position.value = position
     }
 
+    fun setStoreName(storeName: String) {
+        _storeName.value = storeName
+    }
+
     fun setLatLng(latitude: Double, longitude: Double) {
         _lat.value = latitude
         _lng.value = longitude
     }
 
+    fun setStoreLatLng(latitude: Double, longitude: Double) {
+        _storeLat.value = latitude
+        _storeLng.value = longitude
+    }
+
+    /** 位置情報から周辺飲食店を検索 */
     fun getByLocation() {
         viewModelScope.launch {
             byLocation()
@@ -88,6 +128,7 @@ class ViewModel : ViewModel() {
     private suspend fun byLocation() {
         val service = Constants.retrofit()
 
+        _progressBarFlag.value = true
         withContext(Dispatchers.IO) {
             val listCall = lat.value?.let { lat ->
                 lng.value?.let { lng ->
@@ -102,10 +143,14 @@ class ViewModel : ViewModel() {
             listCall?.enqueue(object : Callback<StoreDetail> {
                 override fun onFailure(call: Call<StoreDetail>, t: Throwable) {
                     Log.e("Error", t.message.toString())
+
+                    _progressBarFlag.value = false
                 }
 
                 override fun onResponse(call: Call<StoreDetail>, response: Response<StoreDetail>) {
                     if (response.isSuccessful) {
+
+                        _progressBarFlag.value = false
 
                         val list = response.body()!!
                         makeStoreNameList(list)
@@ -116,6 +161,7 @@ class ViewModel : ViewModel() {
         }
     }
 
+    /** 駅名、ジャンルから飲食店を検索 */
     fun getStoreList() {
         viewModelScope.launch {
             apiConnect()
@@ -126,6 +172,7 @@ class ViewModel : ViewModel() {
     private suspend fun apiConnect() {
         val service = Constants.retrofit()
 
+        _progressBarFlag.value = true
         withContext(Dispatchers.IO) {
             val listCall = service.getStoreList(
                 Constants.API_KEY,
@@ -136,10 +183,14 @@ class ViewModel : ViewModel() {
             listCall.enqueue(object : Callback<StoreDetail> {
                 override fun onFailure(call: Call<StoreDetail>, t: Throwable) {
                     Log.e("Error", t.message.toString())
+
+                    _progressBarFlag.value = false
                 }
 
                 override fun onResponse(call: Call<StoreDetail>, response: Response<StoreDetail>) {
                     if (response.isSuccessful) {
+
+                        _progressBarFlag.value = false
 
                         val list = response.body()!!
                         makeStoreNameList(list)
@@ -156,6 +207,8 @@ class ViewModel : ViewModel() {
         val storeAddressList = mutableListOf<String>()
         val logoImage = mutableListOf<String>()
         val accessList = mutableListOf<String>()
+        val latList = mutableListOf<Double>()
+        val lngList = mutableListOf<Double>()
 
         for (i in list.results.shop.indices) {
             storeNameList += list.results.shop[i].name
@@ -163,12 +216,16 @@ class ViewModel : ViewModel() {
             storeAddressList += list.results.shop[i].address
             logoImage += list.results.shop[i].logo_image
             accessList += list.results.shop[i].access
+            latList += list.results.shop[i].lat
+            lngList += list.results.shop[i].lng
         }
 
         _storeList.value = storeNameList
         _storeGenreList.value = storeGenreList
         _storeAddressList.value = storeAddressList
         _accessList.value = accessList
+        _latList.value = latList
+        _lngList.value = lngList
         Log.i("ViewModel", storeList.value.toString())
     }
 }

--- a/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
+++ b/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
@@ -62,12 +62,12 @@ class ViewModel : ViewModel() {
     val lng: LiveData<Double?>
         get() = _lng
 
-    private val _storeLat = MutableLiveData<Double?>()
-    val storeLat: LiveData<Double?>
+    private val _storeLat = MutableLiveData<Double>()
+    val storeLat: LiveData<Double>
         get() = _storeLat
 
-    private val _storeLng = MutableLiveData<Double?>()
-    val storeLng: LiveData<Double?>
+    private val _storeLng = MutableLiveData<Double>()
+    val storeLng: LiveData<Double>
         get() = _storeLng
 
     private val _storeName = MutableLiveData<String>()
@@ -75,6 +75,7 @@ class ViewModel : ViewModel() {
         get() = _storeName
 
     init {
+        _progressBarFlag.value = false
         _genreCode.value = ""
         _etKeyword.value = ""
         _storeList.value = mutableListOf()
@@ -84,8 +85,8 @@ class ViewModel : ViewModel() {
         _accessList.value = mutableListOf()
         _lat.value = null
         _lng.value = null
-        _storeLat.value = null
-        _storeLng.value = null
+        _storeLat.value = 0.0
+        _storeLng.value = 0.0
         _storeName.value = ""
         _latList.value = mutableListOf()
         _lngList.value = mutableListOf()
@@ -103,16 +104,16 @@ class ViewModel : ViewModel() {
         _position.value = position
     }
 
+    fun setStoreName(storeName: String) {
+        _storeName.value = storeName
+    }
+
     fun setLatLng(latitude: Double?, longitude: Double?) {
         _lat.value = latitude
         _lng.value = longitude
     }
 
-    fun setStoreName(storeName: String) {
-        _storeName.value = storeName
-    }
-
-    fun setStoreLatLng(latitude: Double?, longitude: Double?) {
+    fun setStoreLatLng(latitude: Double, longitude: Double) {
         _storeLat.value = latitude
         _storeLng.value = longitude
     }

--- a/app/src/main/res/layout/fragment_maps.xml
+++ b/app/src/main/res/layout/fragment_maps.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/map"
+    android:name="com.google.android.gms.maps.SupportMapFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragment.MapsFragment" />

--- a/app/src/main/res/layout/fragment_store_detail.xml
+++ b/app/src/main/res/layout/fragment_store_detail.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <variable
             name="dataViewModel"
             type="com.example.hotpepperapi.viewModel.ViewModel" />
@@ -15,7 +14,6 @@
         android:layout_height="match_parent"
         android:background="@color/gray"
         tools:context=".fragment.StoreDetailFragment">
-
 
         <TextView
             android:id="@+id/tv_store_name"

--- a/app/src/main/res/layout/fragment_store_list.xml
+++ b/app/src/main/res/layout/fragment_store_list.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <variable
             name="dataViewModel"
             type="com.example.hotpepperapi.viewModel.ViewModel" />
@@ -27,6 +26,16 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            style="?android:attr/progressBarStyle"/>
 
         <ListView
             android:id="@+id/lv_300"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -25,5 +25,14 @@
     <fragment
         android:id="@+id/storeDetailFragment"
         android:name="com.example.hotpepperapi.fragment.StoreDetailFragment"
-        android:label="StoreDetailFragment" />
+        android:label="StoreDetailFragment" >
+        <action
+            android:id="@+id/action_storeDetailFragment_to_mapsFragment"
+            app:destination="@id/mapsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/mapsFragment"
+        android:name="com.example.hotpepperapi.fragment.MapsFragment"
+        android:label="fragment_maps"
+        tools:layout="@layout/fragment_maps" />
 </navigation>


### PR DESCRIPTION
### **PR対応内容**

- MapsFragment, xmlを追加しました。

### **動作確認内容**

- 店舗詳細画面の住所をタップするとMaps Fragmentに遷移し、Mapが表示される。
- 表示されたMapの店舗にピンが立てられ、選択すると店名が表示される。

### **仕様について**
[アプリの仕様](https://docs.google.com/document/d/1g1koq54AMI1GQBK1CSDwK_GfaSHeKFbhXy4amhJ1LD8/edit?usp=sharing)

### **詳細画面**
![スクリーンショット 2022-11-29 15 29 26](https://user-images.githubusercontent.com/112037699/204455557-5e97a211-78a9-49b4-895d-6d63cf19ab29.png)

### **Map画面**
![スクリーンショット 2022-11-29 15 29 50](https://user-images.githubusercontent.com/112037699/204455647-c7f1e693-e592-4e61-8bbf-e6d18b322469.png)
