### PR TITLE
マップに複数ピン表示、現在地から表示の際、リストかマップ選択

### DIFF
--- a/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
@@ -30,52 +30,40 @@ class MapsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        callback = OnMapReadyCallback { googleMap ->
 
-            viewModel.list.observe(viewLifecycleOwner) { list ->
-                viewModel.multipleFlag.observe(viewLifecycleOwner) { flag ->
 
+        viewModel.list.observe(viewLifecycleOwner) { list ->
+            viewModel.multipleFlag.observe(viewLifecycleOwner) { flag ->
+                viewModel.forMap.observe(viewLifecycleOwner) {
                     if (flag) {
-
                         for (i in list.indices) {
-                            val store = LatLng(list[i].lat, list[i].lng)
-
-                            googleMap.addMarker(
-                                MarkerOptions().position(store).title(list[i].name)
-                            )
-                            googleMap.moveCamera(
-                                CameraUpdateFactory.newLatLngZoom(
-                                    store,
-                                    15F
-                                )
-                            ) //zoom表示
-                            googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
+                            pointLocation(LatLng(list[i].lat, list[i].lng), list[i].name)
+                            val mapFragment =
+                                childFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
+                            mapFragment?.getMapAsync(callback)
                         }
-
                     } else {
+                         pointLocation(LatLng(it!!.lat, it.lng), it.name)
+                        val mapFragment =
+                            childFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
+                        mapFragment?.getMapAsync(callback)
 
-                        viewModel.forMap.observe(viewLifecycleOwner) {
-                            val store = LatLng(it!!.lat, it.lng)
-
-                            googleMap.addMarker(
-                                MarkerOptions().position(store).title(it.name)
-                            )
-                            googleMap.moveCamera(
-                                CameraUpdateFactory.newLatLngZoom(
-                                    store,
-                                    15F
-                                )
-                            ) //zoom表示
-                            googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
-                        }
                     }
                 }
-
-                googleMap.uiSettings.isZoomControlsEnabled = true //zoomボタン表示
             }
         }
+    }
 
-        val mapFragment = childFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
-        mapFragment?.getMapAsync(callback)
+    private fun pointLocation(store: LatLng, name: String) {
+        callback = OnMapReadyCallback { googleMap ->
+            googleMap.addMarker(
+                MarkerOptions().position(store).title(name)
+            )
+            googleMap.moveCamera(
+                CameraUpdateFactory.newLatLngZoom(store, 15F)
+            ) //zoom表示
+            googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
+            googleMap.uiSettings.isZoomControlsEnabled = true //zoomボタン表示
+        }
     }
 }

--- a/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/MapsFragment.kt
@@ -2,7 +2,6 @@ package com.example.hotpepperapi.fragment
 
 import androidx.fragment.app.Fragment
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,20 +32,46 @@ class MapsFragment : Fragment() {
 
         callback = OnMapReadyCallback { googleMap ->
 
-            viewModel.storeLat.observe(viewLifecycleOwner) { lat ->
-                viewModel.storeLng.observe(viewLifecycleOwner) { lng ->
-                    val store = LatLng(lat, lng)
+            viewModel.list.observe(viewLifecycleOwner) { list ->
+                viewModel.multipleFlag.observe(viewLifecycleOwner) { flag ->
 
-                    Log.i("MFlat", viewModel.storeLat.value.toString())
-                    Log.i("MFlng", viewModel.storeLng.value.toString())
+                    if (flag) {
 
-                    googleMap.addMarker(
-                        MarkerOptions().position(store).title(viewModel.storeName.value)
-                    )
-                    googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(store, 15F)) //zoom表示
-                    googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
-                    googleMap.uiSettings.isZoomControlsEnabled = true //zoomボタン表示
+                        for (i in list.indices) {
+                            val store = LatLng(list[i].lat, list[i].lng)
+
+                            googleMap.addMarker(
+                                MarkerOptions().position(store).title(list[i].name)
+                            )
+                            googleMap.moveCamera(
+                                CameraUpdateFactory.newLatLngZoom(
+                                    store,
+                                    15F
+                                )
+                            ) //zoom表示
+                            googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
+                        }
+
+                    } else {
+
+                        viewModel.forMap.observe(viewLifecycleOwner) {
+                            val store = LatLng(it!!.lat, it.lng)
+
+                            googleMap.addMarker(
+                                MarkerOptions().position(store).title(it.name)
+                            )
+                            googleMap.moveCamera(
+                                CameraUpdateFactory.newLatLngZoom(
+                                    store,
+                                    15F
+                                )
+                            ) //zoom表示
+                            googleMap.moveCamera(CameraUpdateFactory.newLatLng(store))
+                        }
+                    }
                 }
+
+                googleMap.uiSettings.isZoomControlsEnabled = true //zoomボタン表示
             }
         }
 

--- a/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/StoreDetailFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.example.hotpepperapi.R
 import com.example.hotpepperapi.databinding.FragmentStoreDetailBinding
+import com.example.hotpepperapi.model.ForMap
 import com.example.hotpepperapi.viewModel.ViewModel
 
 class StoreDetailFragment : Fragment() {
@@ -47,9 +48,10 @@ class StoreDetailFragment : Fragment() {
                 binding.tvStoreAddress.text = list[position].address
                 binding.tvStoreAccess.text = list[position].access
 
-                viewModel.setStoreName(list[position].name)
                 viewModel.setUrl(list[position].urls.pc)
-                viewModel.setStoreLatLng(list[position].lat, list[position].lng)
+
+                val forMap = ForMap(list[position].name, list[position].lat, list[position].lng)
+                viewModel.setForMap(forMap)
             }
         }
 

--- a/app/src/main/java/com/example/hotpepperapi/fragment/TopFragment.kt
+++ b/app/src/main/java/com/example/hotpepperapi/fragment/TopFragment.kt
@@ -89,15 +89,11 @@ class TopFragment : Fragment() {
         binding.cbFreeFood.setOnClickListener { onCheckBoxClicked(it) }
 
         binding.btn300.setSafeClickListener {
-            if (viewModel.lat.value == null || viewModel.lng.value == null){
+            if (viewModel.lat.value == null || viewModel.lng.value == null) {
                 showLocationDialog()
-            }else{
+            } else {
                 checkLocation()
-                viewModel.apiFlag.observe(viewLifecycleOwner){
-                    if (it){
-                        findNavController().navigate(R.id.action_topFragment_to_storeListFragment)
-                    }
-                }
+                select()
             }
         }
 
@@ -126,12 +122,12 @@ class TopFragment : Fragment() {
         if (!binding.etSearchKeyword.text.isNullOrEmpty()) {
 
             viewModel.getStoreList()
-            viewModel.apiFlag.observe(viewLifecycleOwner){
-                if (it){
+            viewModel.apiFlag.observe(viewLifecycleOwner) {
+                if (it) {
                     findNavController().navigate(R.id.action_topFragment_to_storeListFragment)
                 }
             }
-        }else{
+        } else {
             showEditTextDialog()
         }
     }
@@ -148,7 +144,7 @@ class TopFragment : Fragment() {
         }
     }
 
-    private fun showLocationDialog(){
+    private fun showLocationDialog() {
         AlertDialog.Builder(requireContext())
             .setTitle("Caution")
             .setIcon(R.drawable.ic_baseline_warning_24)
@@ -159,13 +155,27 @@ class TopFragment : Fragment() {
             .show()
     }
 
-    private fun showEditTextDialog(){
+    private fun showEditTextDialog() {
         AlertDialog.Builder(requireContext())
             .setTitle("Caution")
             .setIcon(R.drawable.ic_baseline_warning_24)
             .setMessage(R.string.dialog)
             .setPositiveButton("OK") { dialog, _ ->
                 dialog.dismiss()
+            }
+            .show()
+    }
+
+    private fun select() {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.dialogHowto)
+            .setMessage(R.string.selectHowto)
+            .setPositiveButton(R.string.showList) { _, _ ->
+                viewModel.setMultiple(false)
+                findNavController().navigate(R.id.action_topFragment_to_storeListFragment)
+            }
+            .setNegativeButton(R.string.showMap) { _, _ ->
+                findNavController().navigate(R.id.action_topFragment_to_mapsFragment)
             }
             .show()
     }

--- a/app/src/main/java/com/example/hotpepperapi/model/ForMap.kt
+++ b/app/src/main/java/com/example/hotpepperapi/model/ForMap.kt
@@ -1,0 +1,7 @@
+package com.example.hotpepperapi.model
+
+data class ForMap(
+    val name: String,
+    val lat: Double,
+    val lng: Double
+)

--- a/app/src/main/java/com/example/hotpepperapi/model/Results.kt
+++ b/app/src/main/java/com/example/hotpepperapi/model/Results.kt
@@ -1,6 +1,9 @@
 package com.example.hotpepperapi.model
 
+import com.google.gson.annotations.SerializedName
+
 data class Results(
-    val results_available: Int,
+    @SerializedName(value = "results_available")
+    val resultsAvailable: Int,
     val shop: List<Shop>
 ) : java.io.Serializable

--- a/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
+++ b/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
@@ -241,7 +241,7 @@ class ViewModel : ViewModel() {
     }
 
     private fun makeStoreNameList(lists: StoreDetail) {
-        if (lists.results.results_available == 0) {
+        if (lists.results.resultsAvailable == 0) {
             _list.value = mutableListOf()
         } else {
             //APIから返っていくるデータがあれば、元のデータを削除
@@ -252,6 +252,5 @@ class ViewModel : ViewModel() {
             }
             Log.i("ViewModel", list.value.toString())
         }
-
     }
 }

--- a/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
+++ b/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
@@ -110,31 +110,31 @@ class ViewModel : ViewModel() {
         _url.value = url
     }
 
-    fun couponCheck(isChecked: Boolean){
-        if (isChecked){
+    fun couponCheck(isChecked: Boolean) {
+        if (isChecked) {
             _coupon.value = "1"
-        }else{
+        } else {
             _coupon.value = "0"
         }
     }
 
-    fun freeDrinkCheck(isChecked: Boolean){
-        if (isChecked){
+    fun freeDrinkCheck(isChecked: Boolean) {
+        if (isChecked) {
             _freeDrink.value = "1"
-        }else{
+        } else {
             _freeDrink.value = "0"
         }
     }
 
-    fun freeFoodCheck(isChecked: Boolean){
-        if (isChecked){
+    fun freeFoodCheck(isChecked: Boolean) {
+        if (isChecked) {
             _freeFood.value = "1"
-        }else{
+        } else {
             _freeFood.value = "0"
         }
     }
 
-    fun setMultiple(flag: Boolean){
+    fun setMultiple(flag: Boolean) {
         _multipleFlag.value = flag
     }
 

--- a/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
+++ b/app/src/main/java/com/example/hotpepperapi/viewModel/ViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.*
 import androidx.lifecycle.ViewModel
 import com.example.hotpepperapi.Constants
+import com.example.hotpepperapi.model.ForMap
 import com.example.hotpepperapi.model.Shop
 import com.example.hotpepperapi.model.StoreDetail
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +23,10 @@ class ViewModel : ViewModel() {
     private val _apiFlag = MutableLiveData<Boolean>()
     val apiFlag: LiveData<Boolean>
         get() = _apiFlag
+
+    private val _multipleFlag = MutableLiveData<Boolean>()
+    val multipleFlag: LiveData<Boolean>
+        get() = _multipleFlag
 
     private val _genreCode = MutableLiveData<String>()
     val genreCode: LiveData<String>
@@ -43,18 +48,6 @@ class ViewModel : ViewModel() {
     val lng: LiveData<Double?>
         get() = _lng
 
-    private val _storeLat = MutableLiveData<Double>()
-    val storeLat: LiveData<Double>
-        get() = _storeLat
-
-    private val _storeLng = MutableLiveData<Double>()
-    val storeLng: LiveData<Double>
-        get() = _storeLng
-
-    private val _storeName = MutableLiveData<String>()
-    val storeName: LiveData<String>
-        get() = _storeName
-
     private val _coupon = MutableLiveData<String>()
     val coupon: LiveData<String>
         get() = _coupon
@@ -75,22 +68,25 @@ class ViewModel : ViewModel() {
     val url: LiveData<String>
         get() = _url
 
+    private val _forMap = MutableLiveData<ForMap?>()
+    val forMap: LiveData<ForMap?>
+        get() = _forMap
+
     init {
         _progressBarFlag.value = false
         _progressBarFlag.value = false
+        _multipleFlag.value = false
         _genreCode.value = ""
         _etKeyword.value = ""
         _position.value = 0
         _lat.value = null
         _lng.value = null
-        _storeLat.value = 0.0
-        _storeLng.value = 0.0
-        _storeName.value = ""
         _coupon.value = "0"
         _freeDrink.value = "0"
         _freeFood.value = "0"
         _list.value = mutableListOf()
         _url.value = ""
+        _forMap.value = null
     }
 
     fun setKeyword(keyword: String) {
@@ -105,21 +101,12 @@ class ViewModel : ViewModel() {
         _position.value = position
     }
 
-    fun setStoreName(storeName: String) {
-        _storeName.value = storeName
-    }
-
     fun setLatLng(latitude: Double?, longitude: Double?) {
         _lat.value = latitude
         _lng.value = longitude
     }
 
-    fun setStoreLatLng(latitude: Double, longitude: Double) {
-        _storeLat.value = latitude
-        _storeLng.value = longitude
-    }
-
-    fun setUrl(url: String){
+    fun setUrl(url: String) {
         _url.value = url
     }
 
@@ -147,6 +134,14 @@ class ViewModel : ViewModel() {
         }
     }
 
+    fun setMultiple(flag: Boolean){
+        _multipleFlag.value = flag
+    }
+
+    fun setForMap(list: ForMap) {
+        _forMap.value = list
+    }
+
     /** 位置情報から周辺飲食店を検索 */
     fun getByLocation() {
         viewModelScope.launch {
@@ -159,6 +154,7 @@ class ViewModel : ViewModel() {
 
         _progressBarFlag.value = true
         _apiFlag.value = false
+        _multipleFlag.value = true
 
         withContext(Dispatchers.IO) {
             val listCall = lat.value?.let { lat ->
@@ -207,6 +203,7 @@ class ViewModel : ViewModel() {
 
         _progressBarFlag.value = true
         _apiFlag.value = false
+        _multipleFlag.value = false
 
         withContext(Dispatchers.IO) {
             val listCall =
@@ -244,13 +241,13 @@ class ViewModel : ViewModel() {
     }
 
     private fun makeStoreNameList(lists: StoreDetail) {
-        if(lists.results.results_available == 0){
+        if (lists.results.results_available == 0) {
             _list.value = mutableListOf()
-        }else{
+        } else {
             //APIから返っていくるデータがあれば、元のデータを削除
             _list.value = mutableListOf()
 
-            for (i in lists.results.shop.indices){
+            for (i in lists.results.shop.indices) {
                 _list.value?.plusAssign(lists.results.shop[i])
             }
             Log.i("ViewModel", list.value.toString())

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -12,6 +12,9 @@
         <action
             android:id="@+id/action_topFragment_to_storeListFragment"
             app:destination="@id/storeListFragment" />
+        <action
+            android:id="@+id/action_topFragment_to_mapsFragment"
+            app:destination="@id/mapsFragment" />
     </fragment>
     <fragment
         android:id="@+id/storeListFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,10 @@
     <string name="tv_url">店舗サイトはこちらをタップ</string>
 
     <string name="dialogMain">周辺の飲食店を検索する場合は、\n位置情報を有効にして下さい。</string>
+    <string name="dialogHowto">表示方法を選択</string>
+    <string name="selectHowto">リスト表示かマップ表示かを選択して下さい。</string>
+    <string name="showList">リスト表示</string>
+    <string name="showMap">マップ表示</string>
 
     <!--    プルダウンメニュー-->
     <string-array name="spinner_list">


### PR DESCRIPTION
### **PR対応内容**

- Top画面の周辺の飲食店から探すボタンを選択すると、マップ表示かリスト表示を選択し、それぞれ遷移する。
- リスト表示の場合は、今ままで通り店名がリスト表示されます。
- マップ表示の場合は、返ってきたデータの分ピンが地図上に表示されます。

### **動作確認内容**

- 現在地を有効にし、周辺の飲食店から探すボタンを押すとダイアログが表示される。
- リスト表示を選択の場合、店舗名がリスト表示される。
- マップ表示の場合は、マップ上にデータ分ピンが表示されます。

### **仕様について**
[アプリの仕様](https://docs.google.com/document/d/1g1koq54AMI1GQBK1CSDwK_GfaSHeKFbhXy4amhJ1LD8/edit?usp=sharing)

### **ダイアログ画面**
<img width="213" alt="スクリーンショット 2022-12-15 17 16 26" src="https://user-images.githubusercontent.com/112037699/207807933-4162f9ef-ea76-4bc9-9c42-48df2d9da66d.png">

### **現在地からのマップ画面**
<img width="211" alt="スクリーンショット 2022-12-15 17 18 29" src="https://user-images.githubusercontent.com/112037699/207808212-0efee507-127e-4d98-8e61-b9a05eedf6bc.png">
